### PR TITLE
Improve https://www.101weiqi.com/q/297009/

### DIFF
--- a/content.js
+++ b/content.js
@@ -508,6 +508,7 @@ const textReplacements = {
     "官子题目" : "Endgame",
     "完成时间" : "Completion date",
     "安井算知" : "Yasui Sanchi",
+    "如何定形" : "How to stabilize the shape",
     "失败答案" : "Failure answers",
     "天梯训练" : "Ladder training",
     "天下大劫" : "all-dominating ko",

--- a/translations.tsv
+++ b/translations.tsv
@@ -500,6 +500,7 @@ Zero棋谱	ZeroGo
 官子题目	Endgame
 完成时间	Completion date
 安井算知	Yasui Sanchi
+如何定形	How to stabilize the shape
 失败答案	Failure answers
 天梯训练	Ladder training
 天下大劫	all-dominating ko


### PR DESCRIPTION
Add 如何定形 as "How to stabilize the shape".

Given that I already added 如何 as "How" in another PR, and I think it would make sense to change 定形  to always mean "stabilize the shape", without translating the whole sentence.

However, 定形 is already translated as "shape", and the change history shows that it comes from firefox bulk import, so it's hard to see if this would have negative consequences.